### PR TITLE
feat(options): add optional Options arguments to New() function

### DIFF
--- a/golden.go
+++ b/golden.go
@@ -257,14 +257,21 @@ type Golden struct {
 }
 
 // New returns a new *Golden instance with default values correctly populated.
-func New() *Golden {
-	return &Golden{
+// It accepts zero or more Option functions that can modify the default values.
+func New(opts ...Option) *Golden {
+	g := &Golden{
 		DirMode:    DefaultDirMode,
 		FileMode:   DefaultFileMode,
 		Suffix:     DefaultSuffix,
 		Dirname:    DefaultDirname,
 		UpdateFunc: DefaultUpdateFunc,
 	}
+
+	for _, opt := range opts {
+		opt(g)
+	}
+
+	return g
 }
 
 // Do is a convenience function for calling Update(), Set(), and Get() in a

--- a/options.go
+++ b/options.go
@@ -1,0 +1,43 @@
+package golden
+
+import (
+	"os"
+)
+
+// Option is a function that modifies a Golden instance.
+type Option func(*Golden)
+
+// WithDirMode sets the directory mode for a Golden instance.
+func WithDirMode(mode os.FileMode) Option {
+	return func(g *Golden) {
+		g.DirMode = mode
+	}
+}
+
+// WithFileMode sets the file mode for a Golden instance.
+func WithFileMode(mode os.FileMode) Option {
+	return func(g *Golden) {
+		g.FileMode = mode
+	}
+}
+
+// WithSuffix sets the file suffix for a Golden instance.
+func WithSuffix(suffix string) Option {
+	return func(g *Golden) {
+		g.Suffix = suffix
+	}
+}
+
+// WithDirname sets the directory name for a Golden instance.
+func WithDirname(dirname string) Option {
+	return func(g *Golden) {
+		g.Dirname = dirname
+	}
+}
+
+// WithUpdateFunc sets the update function for a Golden instance.
+func WithUpdateFunc(updateFunc UpdateFunc) Option {
+	return func(g *Golden) {
+		g.UpdateFunc = updateFunc
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,58 @@
+package golden
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithDirMode(t *testing.T) {
+	customMode := os.FileMode(0o700)
+	g := &Golden{}
+
+	opt := WithDirMode(customMode)
+	opt(g)
+
+	assert.Equal(t, customMode, g.DirMode)
+}
+
+func TestWithFileMode(t *testing.T) {
+	customMode := os.FileMode(0o600)
+	g := &Golden{}
+
+	opt := WithFileMode(customMode)
+	opt(g)
+
+	assert.Equal(t, customMode, g.FileMode)
+}
+
+func TestWithSuffix(t *testing.T) {
+	customSuffix := ".custom"
+	g := &Golden{}
+
+	opt := WithSuffix(customSuffix)
+	opt(g)
+
+	assert.Equal(t, customSuffix, g.Suffix)
+}
+
+func TestWithDirname(t *testing.T) {
+	customDirname := "custom-testdata"
+	g := &Golden{}
+
+	opt := WithDirname(customDirname)
+	opt(g)
+
+	assert.Equal(t, customDirname, g.Dirname)
+}
+
+func TestWithUpdateFunc(t *testing.T) {
+	customUpdateFunc := func() bool { return true }
+	g := &Golden{}
+
+	opt := WithUpdateFunc(customUpdateFunc)
+	opt(g)
+
+	assertSameFunc(t, customUpdateFunc, g.UpdateFunc)
+}


### PR DESCRIPTION
Enables simpler creation of custom *Golden instances, as you can just pass in the custom values to New(), rather than modifying fields after increating the Golden instance.